### PR TITLE
Add troubleshooting section to developing guide

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -89,3 +89,13 @@ If you also need to specify a different models directory:
 And if you need to specify the Data Hub Framework environment (it defaults to local):
 
 `java -DdhfEnv=prod -DdhfDir=/full/path/to/your/datahub -DmodelsDir=/full/path/to/your/models/dir -jar envision.jar`
+
+#### Troubleshooting
+
+##### Missing/Incorrect Concept Connector Model
+
+* Are you seeing URIs on the Explore tab instead of meaningful labels?  
+* Is the merge screen showing `   ,   ` instead of `Finn, Finn`?
+
+You have not loaded the proper concept connector model for current dataset in the Data Hib.  To get working again, navigate to the "Connect" tab.  On the right panel, select "Load Model" and select the proper model for your dataset.  For the standard HR demo, pick "HR Employee 360".    
+

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -97,5 +97,5 @@ And if you need to specify the Data Hub Framework environment (it defaults to lo
 * Are you seeing URIs on the Explore tab instead of meaningful labels?  
 * Is the merge screen showing `   ,   ` instead of `Finn, Finn`?
 
-You have not loaded the proper concept connector model for current dataset in the Data Hib.  To get working again, navigate to the "Connect" tab.  On the right panel, select "Load Model" and select the proper model for your dataset.  For the standard HR demo, pick "HR Employee 360".    
+You have not loaded the proper concept connector model for current dataset in the Data Hub.  To get working again, navigate to the "Connect" tab.  On the right panel, select "Load Model" and select the proper model for your dataset.  For the standard HR use case, pick "HR Employee 360".    
 

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Please go read the [Contributing doc](./CONTRIBUTING.md).
 Then go read the [Developing doc](./DEVELOPING.md) for info on building and running the project.
 
 
-[jar]: https://github.com/marklogic-community/envision/releases/download/v1.0.2/envision-1.0.2.jar
+[jar]: https://github.com/marklogic-community/envision/releases/download/v1.0.4/envision-1.0.4.jar


### PR DESCRIPTION
Add in a troubleshooting section, seeded initially with details on how Envision behaves when an incorrect concept connector model is loaded.