### PR TITLE
Feature/issue 12

### DIFF
--- a/ui/src/components/EditProperty.vue
+++ b/ui/src/components/EditProperty.vue
@@ -55,20 +55,7 @@
 								></v-checkbox>
 							</v-flex>
 							<v-flex md6>
-								<!--
-								<v-checkbox
-									v-if="primaryKey == '' || (prop && primaryKey == prop.name) "
-									data-cy="prop.isPrimaryKey"
-									v-model="isPrimaryKey"
-									label="Primary Key"
-								></v-checkbox>
-								<v-checkbox
-									v-else
-									data-cy="prop.isPrimaryKey"
-									:label="'Primary Key is ' + primaryKey"
-									value disabled
-								></v-checkbox>
-								-->
+								
 								<v-checkbox
 									v-if="primaryKey == '' || (prop && primaryKey == prop.name) "
 									data-cy="prop.isPrimaryKey"

--- a/ui/src/components/EditProperty.vue
+++ b/ui/src/components/EditProperty.vue
@@ -55,11 +55,34 @@
 								></v-checkbox>
 							</v-flex>
 							<v-flex md6>
+								<!--
 								<v-checkbox
+									v-if="primaryKey == '' || (prop && primaryKey == prop.name) "
 									data-cy="prop.isPrimaryKey"
 									v-model="isPrimaryKey"
 									label="Primary Key"
 								></v-checkbox>
+								<v-checkbox
+									v-else
+									data-cy="prop.isPrimaryKey"
+									:label="'Primary Key is ' + primaryKey"
+									value disabled
+								></v-checkbox>
+								-->
+								<v-checkbox
+									v-if="primaryKey == '' || (prop && primaryKey == prop.name) "
+									data-cy="prop.isPrimaryKey"
+									v-model="isPrimaryKey"
+									label="Primary Key"
+								></v-checkbox>
+								<v-checkbox
+									v-else
+									data-cy="prop.isPrimaryKey"
+									:label="'Change Primary Key from ' + primaryKey"
+									v-model="isPrimaryKey"
+									v-on:click="removeOldPK"
+								></v-checkbox>
+
 								<v-checkbox
 									data-cy="prop.isRequired"
 									v-model="isRequired"
@@ -79,7 +102,7 @@
 		</v-container>
 		<v-card-actions>
 			<v-spacer></v-spacer>
-			<v-btn text color="secondary" @click="cancel">Cancel</v-btn>
+			<v-btn data-cy="editProperty.cancelBtn"text color="secondary" @click="cancel">Cancel</v-btn>
 			<v-btn data-cy="editProperty.createBtn" type="submit" text color="primary">Save</v-btn>
 		</v-card-actions>
 	</v-card>
@@ -115,6 +138,17 @@ export default {
 		},
 		dataTypeWithArray() {
 			return [{ text: "array", value: "array" }].concat(this.dataTypes)
+		},
+		primaryKey() { 
+			// feature/issue-12 - check to see if any prop is defined as a primary key
+			if (this.existingProperties) {
+				for (var i=0; i<this.existingProperties.length; i++) {
+					if ( this.existingProperties[i].isPrimaryKey) {
+						return this.existingProperties[i].name
+					}
+				}
+			}
+			return ""
 		}
 	},
 	data: () => ({
@@ -147,6 +181,16 @@ export default {
 		isWordLexicon: false
 	}),
 	methods: {
+		removeOldPK(){
+			if (this.existingProperties) {
+				for (var i=0; i<this.existingProperties.length; i++) {
+					if (this.existingProperties[i].name != this.name ) {
+						this.existingProperties[i].isPrimaryKey = false
+					}	
+				}
+			}
+			this.isPrimaryKey = true
+		},
 		reset() {
 			this.advancedState = 0
 			this.name = null
@@ -181,8 +225,17 @@ export default {
 				}
 			}
 			else {
+				// feature/issue-12 - reset all values
 				this.type = 'string'
+				this.name = ""
+				this.isRequired = false
+				this.isPii = false
+				this.isPrimaryKey = false
+				this.isElementRangeIndex = false
+				this.isRangeIndex = false
+				this.isWordLexicon = false
 			}
+
 		},
 		save() {
 			if (!this.name || this.name.length === 0) {

--- a/ui/tests/e2e/specs/entityUpdate.js
+++ b/ui/tests/e2e/specs/entityUpdate.js
@@ -254,8 +254,7 @@ describe('End to end test to create and update model', () => {
 		cy.get('[data-cy="prop.isRangeIndex"]').should('not.be.checked')
 		cy.get('[data-cy="prop.isWordLexicon"]').should('not.be.checked')
 	})
-
-	// TODO: FIX THIS
+ 
 	it('can only have one primary key', () => {
 		cy.route('GET', '/api/models/', [{"name":"Test Model","edges":{},"nodes":{"poet":{"id":"poet","x":-156.3861003861004,"y":-130.42857142857144,"label":"Poet","entityName":"Poet","type":"entity","properties":[{"_propId": "abc123", "name": "id", "type": "string", "isPrimaryKey": true, "isPii": true},{ "_propId": "9c6144b2-4d75-4e6c-bd7e-7319b48039c7", "name": "address", "type": "string" }]}}}])
 		cy.visit('/')
@@ -263,10 +262,44 @@ describe('End to end test to create and update model', () => {
 
 		cy.get('.hideUnlessTesting').invoke('css', 'visibility', 'visible')
 		cy.get('[data-cy=nodeList]').contains("poet").click()
-		cy.get('[data-cy="entityPickList.editPropertyBtn"]').first().click()
+
+		// Starting point has 'id' as the primary key. 'address' is the first property in the display (assumed alpha
+		// order). Clicking the pk button for the 'address' property should make it the pk and the pk attribute should 
+		// be removed from the 'id' prop
+
+		cy.log("id (the last attribute in the list) should have pk selected")
+		cy.get('[data-cy="entityPickList.editPropertyBtn"]').last().click()
 		cy.get('[data-cy="editProperty.advancedBtn"]').click()
-		cy.get('[data-cy="prop.isPrimaryKey"]').parentsUntil('.v-input__slot').click()
-		cy.get('[data-cy="editProperty.createBtn"]').click()
+		cy.get('[data-cy="prop.isPrimaryKey"]').should('be.checked')
+		cy.get('[data-cy="editProperty.cancelBtn"]').click()
+
+		cy.log("make address the PK then check that the id attr does not have pk selected")
+		cy.get('[data-cy="entityPickList.editPropertyBtn"]').first().click()
+		cy.get('[data-cy="editProperty.advancedBtn"]').last().click()
+		cy.get('[data-cy="prop.isPrimaryKey"]').last().should('not.be.checked')
+		cy.get('[data-cy="prop.isPrimaryKey"]').last().parentsUntil('.v-input__slot').first().click()
+		cy.get('[data-cy="prop.isPrimaryKey"]').last().should('be.checked')
+		cy.get('[data-cy="editProperty.createBtn"]').last().click()
+		// check id attr
+		cy.get('[data-cy="entityPickList.editPropertyBtn"]').last().click()
+		cy.get('[data-cy="editProperty.advancedBtn"]').first().click()
+		cy.get('[data-cy="prop.isPrimaryKey"]').first().should('not.be.checked')
+		cy.get('[data-cy="editProperty.cancelBtn"]').first().click()
+
+		cy.log("check we can unselect the PK, so nothing has a PK")
+		cy.get('[data-cy="entityPickList.editPropertyBtn"]').first().click()
+		cy.get('[data-cy="editProperty.advancedBtn"]').last().click()
+		cy.get('[data-cy="prop.isPrimaryKey"]').last().should('be.checked')
+		cy.get('[data-cy="prop.isPrimaryKey"]').last().parentsUntil('.v-input__slot').first().click()
+		cy.get('[data-cy="prop.isPrimaryKey"]').last().should('not.be.checked')
+		cy.get('[data-cy="editProperty.createBtn"]').last().click()
+		// check id attr
+		cy.get('[data-cy="entityPickList.editPropertyBtn"]').last().click()
+		cy.get('[data-cy="editProperty.advancedBtn"]').first().click()
+		cy.get('[data-cy="prop.isPrimaryKey"]').first().should('not.be.checked')
+		cy.get('[data-cy="editProperty.cancelBtn"]').first().click()
+
+		
 	})
 
 	it('can not edit Info.iri with invalid stuff', () => {


### PR DESCRIPTION
When editing entity properties a user can choose that the property will be the entities primary key. This change ensures there can only be one property that is the primary key. The advanced property editing pages shows the user which property is the primary, and enables the user to change this to the property they are editing