### PR TITLE
Issue-60 - right click on concepts on explore tab to expand

### DIFF
--- a/middle-tier/src/main/java/com/marklogic/envision/dataServices/EntitySearcher.java
+++ b/middle-tier/src/main/java/com/marklogic/envision/dataServices/EntitySearcher.java
@@ -50,6 +50,22 @@ public interface EntitySearcher {
 
 
             @Override
+            public com.fasterxml.jackson.databind.JsonNode relatedEntitiesToConcept(String concept, Integer page, Integer pageLength) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                baseProxy
+                .request("relatedEntitiesToConcept.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS)
+                .withSession()
+                .withParams(
+                    BaseProxy.atomicParam("concept", false, BaseProxy.StringType.fromString(concept)),
+                    BaseProxy.atomicParam("page", false, BaseProxy.IntegerType.fromInteger(page)),
+                    BaseProxy.atomicParam("pageLength", false, BaseProxy.IntegerType.fromInteger(pageLength)))
+                .withMethod("POST")
+                .responseSingle(false, Format.JSON)
+                );
+            }
+
+
+            @Override
             public com.fasterxml.jackson.databind.JsonNode relatedEntities(String uri, String label, Integer page, Integer pageLength) {
               return BaseProxy.JsonDocumentType.toJsonNode(
                 baseProxy
@@ -97,6 +113,16 @@ public interface EntitySearcher {
    * @return	as output
    */
     com.fasterxml.jackson.databind.JsonNode findEntities(String qtext, Integer page, Integer pageLength, String sort, String searchQuery);
+
+  /**
+   * Invokes the relatedEntitiesToConcept operation on the database server
+   *
+   * @param concept	provides input
+   * @param page	provides input
+   * @param pageLength	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode relatedEntitiesToConcept(String concept, Integer page, Integer pageLength);
 
   /**
    * Invokes the relatedEntities operation on the database server

--- a/middle-tier/src/main/java/com/marklogic/envision/explore/ExploreController.java
+++ b/middle-tier/src/main/java/com/marklogic/envision/explore/ExploreController.java
@@ -133,5 +133,17 @@ public class ExploreController extends AbstractController {
 		int page = node.get("page").asInt();
 		int pageLength = node.get("pageLength").asInt();
         return EntitySearcher.on(client).relatedEntities(uri, label, page, pageLength);
-    }
+	}
+
+
+	@RequestMapping(value = "/related-entities-to-concept", method = RequestMethod.POST)
+	JsonNode getRelatedEntitiesToConcept(HttpSession session, HttpServletRequest request, HttpServletResponse response) throws IOException {
+		DatabaseClient client = getFinalClient();
+
+		JsonNode node = om.readTree(request.getInputStream());
+		String concept = node.get("concept").asText();
+		int page = node.get("page").asInt();
+		int pageLength = node.get("pageLength").asInt();
+		return EntitySearcher.on(client).relatedEntitiesToConcept(concept, page, pageLength);
+	}
 }

--- a/middle-tier/src/main/java/com/marklogic/envision/explore/RelatedEntitiesToConceptResource.java
+++ b/middle-tier/src/main/java/com/marklogic/envision/explore/RelatedEntitiesToConceptResource.java
@@ -1,0 +1,38 @@
+package com.marklogic.envision.explore;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.extensions.ResourceManager;
+import com.marklogic.client.extensions.ResourceServices;
+import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.util.RequestParameters;
+
+import java.io.IOException;
+
+public class RelatedEntitiesToConceptResource extends ResourceManager {
+
+    private static final String NAME = "related-entities-to-concept";
+
+    public RelatedEntitiesToConceptResource(DatabaseClient client) {
+        super();
+        client.init(NAME, this);
+    }
+
+    public String getRelatedEntitiesToConcept(InputStreamHandle body) {
+        RequestParameters params = new RequestParameters();
+        try {
+            ResourceServices.ServiceResultIterator resultItr = this.getServices().post(params, body);
+            if (resultItr == null || !resultItr.hasNext()) {
+                throw new IOException("Unable to get related entities to concept");
+            }
+            ResourceServices.ServiceResult res = resultItr.next();
+            return res.getContent(new StringHandle()).get();
+        }
+        catch(IOException e) {
+            e.printStackTrace();
+        }
+        return "";
+
+    }
+}
+

--- a/middle-tier/src/main/resources/envision-modules/root/envision/search/relatedEntitiesToConcept.api
+++ b/middle-tier/src/main/resources/envision-modules/root/envision/search/relatedEntitiesToConcept.api
@@ -1,0 +1,21 @@
+{
+    "functionName": "relatedEntitiesToConcept",
+    "params": [
+      {
+        "datatype": "string",
+        "name": "concept"
+      },
+			{
+        "datatype": "int",
+        "name": "page"
+      },
+			{
+        "datatype": "int",
+        "name": "pageLength"
+      }
+    ],
+    "return": {
+      "datatype": "jsonDocument",
+      "$javaClass":"com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/middle-tier/src/main/resources/envision-modules/root/envision/search/relatedEntitiesToConcept.sjs
+++ b/middle-tier/src/main/resources/envision-modules/root/envision/search/relatedEntitiesToConcept.sjs
@@ -1,0 +1,9 @@
+'use strict';
+// declareUpdate(); // Note: uncomment if changing the database state
+
+var concept; // instance of xs.string
+var page; // instance of xs.int
+var pageLength; // instance of xs.int
+
+// TODO:  produce the DocumentNode output from the input variables
+

--- a/ui/src/api/SearchApi.js
+++ b/ui/src/api/SearchApi.js
@@ -230,5 +230,13 @@ export default {
 			console.error('error:', error);
 			return error;
 		});
+	},
+	getEntitiesRelatedToConcept ({ concept, page, pageLength }) {
+		return axios.post('/api/explore/related-entities-to-concept/', { concept, page, pageLength })
+		.then(response => response.data)
+		.catch(error => {
+			console.error('error:', error);
+			return error;
+		});
 	}
 };

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -386,6 +386,13 @@ const explore = {
 					commit('addDocs', response)
 				})
 		},
+		getEntitiesRelatedToConcept({ commit }, { concept, page, pageLength }) {
+			return searchApi
+				.getEntitiesRelatedToConcept({ concept, page, pageLength })
+				.then(response => {
+					commit('addDocs', response)
+				})
+		},
 		getHistory({ commit }, uri) {
 			return masteringApi.getHistory(uri)
 				.then(response => {

--- a/ui/src/views/ExplorerPage.vue
+++ b/ui/src/views/ExplorerPage.vue
@@ -706,7 +706,7 @@ export default {
 						y: e.event.y
 					}
 
-					let items = _.sortBy(Object.values(node.edgeCounts), 'label').map(e => {
+					/* let items = _.sortBy(Object.values(node.edgeCounts), 'label').map(e => {
 						return {
 							label: `Expand ${e.label} (${e.count})`,
 							action: 'expand',
@@ -716,6 +716,30 @@ export default {
 							}
 						}
 					})
+					*/
+					let items = []
+					if (!node.isConcept) {
+						items = _.sortBy(Object.values(node.edgeCounts), 'label').map(e => {
+							return {
+								label: `Expand ${e.label} (${e.count})`,
+								action: 'expand',
+								rel: {
+									uri: this.currentNode.id,
+									label: e.label
+								}
+							}
+						})
+					} else {
+						// TODO - change to be like normal entities and show numbers?
+						items.push({
+							label: 'Expand concept ' + node.label,
+							action: 'expandConcept',
+							rel: {
+								concept: node.label
+							}
+						})
+          }
+
 
 					if (node.uri && node.uri.match('/com.marklogic.smart-mastering/merged/')) {
 						items.push({
@@ -747,6 +771,9 @@ export default {
 				case 'expand':
 					this.expandRelationship(item.rel)
 					break
+				case 'expandConcept':
+					this.expandConcept(item.rel)
+					break;
 				case 'unmerge':
 					this.confirmUnmergeMenu = true
 					break;
@@ -760,6 +787,12 @@ export default {
 			const page = 1
 			const pageLength = 10
 			this.$store.dispatch('explore/getRelatedEntities', { uri, label, page, pageLength })
+		},
+		expandConcept({ concept }) {
+			// TODO: move this to store
+			const page = 1
+			const pageLength = 10
+			this.$store.dispatch('explore/getEntitiesRelatedToConcept', { concept, page, pageLength })
 		},
 		mergeHistory(uri) {
 			this.$router.push({ name: 'root.explorer.compare', query: { uri } })


### PR DESCRIPTION
Slightly different behaviour when right clicking on concepts - with entities we show related items by type so you can determine what you want to expand. For concepts you expand everything. (Should probably allow both approaches - ie expand all and expand by type)