### PR TITLE
Issue-79 showing and hiding the detail panel

### DIFF
--- a/ui/src/components/ml-explorer/EntityDetails.vue
+++ b/ui/src/components/ml-explorer/EntityDetails.vue
@@ -55,6 +55,20 @@
 				</template>
 				<span>View Document</span>
 			</v-tooltip>
+
+			<v-tooltip bottom>
+				<template v-slot:activator="{ on }">
+					<v-btn
+						data-cy="entity.hideBtn"
+						@click="$emit('hideDetails')"
+						right icon small class="small-btn" v-on="on">
+						<v-icon>unfold_less</v-icon>
+					</v-btn>
+				</template>
+				<span>Hide detail pane</span>
+			</v-tooltip>
+
+
 		</v-card-title>
 		<v-card-text class="overflow">
 			<v-tabs

--- a/ui/src/views/ExplorerPage.vue
+++ b/ui/src/views/ExplorerPage.vue
@@ -37,7 +37,7 @@
 			</v-layout>
 			<v-flex md12>
 				<v-layout row class="fullHeight">
-					<v-flex :class="['graph-container', currentNode ? 'md8' : 'md12']">
+					<v-flex :class="['graph-container', (currentNode  && showDetailPane) ? 'md8' : 'md12']">
 						<div row>
 							<v-tabs v-if="isFinalDb" v-model="tab" @change="updateRoute" hide-slider>
 								<v-tab data-cy="tabGraph"><v-icon>bubble_chart</v-icon>Graph</v-tab>
@@ -87,12 +87,14 @@
 							<li v-for="node in nodes" :key="node.id" data-cy="nodeList" v-on:click="selectNode(node)">{{ node.id }}</li>
 						</ul>
 					</v-flex>
-					<v-flex :class="['right-pane', currentNode ? 'md4' : 'nowidth']">
+					<v-flex :class="['right-pane', (currentNode && showDetailPane)? 'md4' : 'nowidth']">
 						<entity-details
 							v-if="currentNode && !currentNode.isConcept"
 							:entity="currentNode"
 							v-on:expandRelationship="expandRelationship"
-							v-on:unmerge="unmerge"></entity-details>
+							v-on:unmerge="unmerge"
+							v-on:hideDetails="showDetailPane = false"
+							></entity-details>
 						<v-card
 							v-if="currentNode && currentNode.isConcept">
 							<v-card-text>
@@ -200,6 +202,7 @@ export default {
 			rightClickPos: { x: 0, y: 0 },
 			rightClickItems: [],
 			currentNode: null,
+			showDetailPane: false,
 			title: 'Explore',
 			entities: {},
 			colors: {},
@@ -523,6 +526,7 @@ export default {
 		clickedResult(result) {
 			if (this.isFinalDb) {
 				this.currentNode = result
+				this.showDetailPane = true
 			}
 			else {
 				this.$router.push({ name: 'root.details', query: { uri: result.uri, db: this.currentDatabase } })
@@ -679,11 +683,13 @@ export default {
 				let node = this.nodeMap[nodeId]
 				if (node) {
 					this.currentNode = node
+					this.showDetailPane = true
 				}
 				else {
 					let concept = this.concepts.find(c => c.id === nodeId)
 					if (concept) {
 						this.currentNode = concept
+						this.showDetailPane = true
 					}
 				}
 			} else if (!isDrag) {

--- a/ui/tests/e2e/specs/explore.js
+++ b/ui/tests/e2e/specs/explore.js
@@ -150,6 +150,23 @@ describe('Explore', () => {
 		cy.get('code.json.hljs').contains('envelope')
 	})
 
+	it('Grid Result close details page', () => {
+		cy.visit('/explore')
+		cy.get('[data-cy=searchInput]').clear()
+		cy.get('[data-cy=searchInput]').type('Sashenka{enter}')
+		cy.contains('Showing results 1 to 5 of 31')
+
+		cy.url().should('equal', 'http://localhost:9999/explore?tab=0&q=Sashenka&page=1&db=final')
+		cy.get('[data-cy=tabGrid]').click()
+		cy.url().should('equal', 'http://localhost:9999/explore?tab=1&q=Sashenka&page=1&db=final')
+
+		cy.get('h3').contains('Sashenka').parent().click()
+		cy.get('[data-cy=entityTitle]').contains("Sashenka")
+		cy.contains('571 Grayhawk Court')
+		cy.get('[data-cy="entity.hideBtn"]').click()
+		cy.get('[data-cy="entity.entityTitle"]').should('not.be.visible')
+	})
+
 	it('Property panel cleared after search', () => {
 		cy.visit('/explore')
 		cy.get('[data-cy=searchInput]').clear()


### PR DESCRIPTION
On explore page, left click on graph or grid results shows detail panel. Button added to panel to hide it. Right click on graph node will not show detail panel if it is not already displayed. If it is already displayed, panel will be populated the node the user right clicked on. 