### PR TITLE
Issue-60 - right click on concepts on explore tab to expand

### DIFF
--- a/middle-tier/src/main/java/com/marklogic/envision/dataServices/EntitySearcher.java
+++ b/middle-tier/src/main/java/com/marklogic/envision/dataServices/EntitySearcher.java
@@ -50,6 +50,22 @@ public interface EntitySearcher {
 
 
             @Override
+            public com.fasterxml.jackson.databind.JsonNode relatedEntitiesToConcept(String concept, Integer page, Integer pageLength) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                baseProxy
+                .request("relatedEntitiesToConcept.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS)
+                .withSession()
+                .withParams(
+                    BaseProxy.atomicParam("concept", false, BaseProxy.StringType.fromString(concept)),
+                    BaseProxy.atomicParam("page", false, BaseProxy.IntegerType.fromInteger(page)),
+                    BaseProxy.atomicParam("pageLength", false, BaseProxy.IntegerType.fromInteger(pageLength)))
+                .withMethod("POST")
+                .responseSingle(false, Format.JSON)
+                );
+            }
+
+
+            @Override
             public com.fasterxml.jackson.databind.JsonNode relatedEntities(String uri, String label, Integer page, Integer pageLength) {
               return BaseProxy.JsonDocumentType.toJsonNode(
                 baseProxy
@@ -97,6 +113,16 @@ public interface EntitySearcher {
    * @return	as output
    */
     com.fasterxml.jackson.databind.JsonNode findEntities(String qtext, Integer page, Integer pageLength, String sort, String searchQuery);
+
+  /**
+   * Invokes the relatedEntitiesToConcept operation on the database server
+   *
+   * @param concept	provides input
+   * @param page	provides input
+   * @param pageLength	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode relatedEntitiesToConcept(String concept, Integer page, Integer pageLength);
 
   /**
    * Invokes the relatedEntities operation on the database server

--- a/middle-tier/src/main/java/com/marklogic/envision/explore/ExploreController.java
+++ b/middle-tier/src/main/java/com/marklogic/envision/explore/ExploreController.java
@@ -133,5 +133,16 @@ public class ExploreController extends AbstractController {
 		int page = node.get("page").asInt();
 		int pageLength = node.get("pageLength").asInt();
         return EntitySearcher.on(client).relatedEntities(uri, label, page, pageLength);
-    }
+	}
+
+	@RequestMapping(value = "/related-entities-to-concept", method = RequestMethod.POST)
+	JsonNode getRelatedEntitiesToConcept(HttpSession session, HttpServletRequest request, HttpServletResponse response) throws IOException {
+		DatabaseClient client = getFinalClient();
+
+		JsonNode node = om.readTree(request.getInputStream());
+		String concept = node.get("concept").asText();
+		int page = node.get("page").asInt();
+		int pageLength = node.get("pageLength").asInt();
+		return EntitySearcher.on(client).relatedEntitiesToConcept(concept, page, pageLength);
+	}
 }

--- a/middle-tier/src/main/java/com/marklogic/envision/explore/RelatedEntitiesToConceptResource.java
+++ b/middle-tier/src/main/java/com/marklogic/envision/explore/RelatedEntitiesToConceptResource.java
@@ -1,0 +1,37 @@
+package com.marklogic.envision.explore;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.extensions.ResourceManager;
+import com.marklogic.client.extensions.ResourceServices;
+import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.util.RequestParameters;
+
+import java.io.IOException;
+
+public class RelatedEntitiesToConceptResource extends ResourceManager {
+
+    private static final String NAME = "related-entities-to-concept";
+
+    public RelatedEntitiesToConceptResource(DatabaseClient client) {
+        super();
+        client.init(NAME, this);
+    }
+
+    public String getRelatedEntitiesToConcept(InputStreamHandle body) {
+        RequestParameters params = new RequestParameters();
+        try {
+            ResourceServices.ServiceResultIterator resultItr = this.getServices().post(params, body);
+            if (resultItr == null || !resultItr.hasNext()) {
+                throw new IOException("Unable to get related entities to concept");
+            }
+            ResourceServices.ServiceResult res = resultItr.next();
+            return res.getContent(new StringHandle()).get();
+        }
+        catch(IOException e) {
+            e.printStackTrace();
+        }
+        return "";
+
+    }
+}

--- a/middle-tier/src/main/resources/envision-modules/root/envision/entities.sjs
+++ b/middle-tier/src/main/resources/envision-modules/root/envision/entities.sjs
@@ -129,30 +129,7 @@ function getEntities(uris, opts) {
 			toType: t.toType
 		}
 
-		if (t.isConcept) {
-			// determine which "side" (from or to) has the concept
-			if (fn.head(t.fromUri)) {
-				// to side has concept
-				resp.nodes[t.to] = {
-					id: t.to,
-					label: t.to.toString().replace(/(.+)#(.+)/, '$2'),
-					entityName: model.getName(t.toType),
-					isConcept: true,
-					edgeCounts: {}
-				}
-			}
-			else {
-				// from side has concept
-				resp.nodes[t.from] = {
-					id: t.from,
-					label: t.from.toString().replace(/(.+)#(.+)/, '$2'),
-					entityName: model.getName(t.fromType),
-					isConcept: true,
-					edgeCounts: {}
-				}
-			}
-		}
-		else {
+		if (! t.isConcept ) {
 			// ensure uris from both sides of the triple are in the uris map
 			if (t.to && t.to.length > 0) {
 				uriMap[t.to] = true
@@ -224,6 +201,31 @@ function getEntities(uris, opts) {
 		}
 	})
 
+	// Add the concepts (nodes were added above)
+	for (let t of triples) {
+		if (t.isConcept) {
+			// determine which "side" (from or to) has the concept
+			if (fn.head(t.fromUri)) {
+				// to side has concept
+				resp.nodes[t.to] = {
+					id: t.to,
+					label: t.to.toString().replace(/(.+)#(.+)/, '$2'),
+					entityName: model.getName(t.toType),
+					isConcept: true,
+					edgeCounts: edgeCounts[t.to] || {} // DGB here and below to do differently
+				}
+			}	else {
+				// from side has concept
+				resp.nodes[t.from] = {
+					id: t.from,
+					label: t.from.toString().replace(/(.+)#(.+)/, '$2'),
+					entityName: model.getName(t.fromType),
+					isConcept: true,
+					edgeCounts: edgeCounts[t.from] || {}
+				}
+			}
+		}
+	}
 	return resp
 }
 
@@ -357,6 +359,149 @@ function getValues(qtext, query, facetName) {
 	return fn.head(xdmp.toJSON(json.transformToJsonObject(root, sut.buildValResultsConfig()))).root.toObject();
 }
 
+/**
+* This method takes a given array of uris and returns the # of edges
+* for each uri
+*
+* @param concept an array of concepts to get
+* @param opts an options object
+* Options:
+* 		start - start index for pagination
+* 		connectionLimit - # of connections to grab
+* 		labels - an array of edge labels to return, empty means all
+*
+* 		Called from a concept - based on getEntities - finds entities related to the concept then
+*		calls getEntities to populate the graph
+*/
+function getEntitiesRelatedToConcept(concepts, opts) {
+	let options = opts || {}
+	let start = (!!options.start) ? options.start : 0
+	let connectionLimit = (!!options.connectionLimit) ? options.connectionLimit : 10
+
+	const resp = {
+		nodes: {},
+		edges: {}
+	}
+	if (concepts.length < 1) {
+		return resp
+	}
+	// concepts may be an array like ['Manufacturing' , 'general ledger']. This code turns this into the sparql filter:
+	// FILTER ( STRENDS (?concept,'Manufacturing') || STRENDS (?concept,'general ledger') )
+	let conceptFilterFromConcept = `FILTER ( ${concepts.map(concept => `STRENDS (?fromId,'${concept}')` ) .join (" || ")} )`
+	let conceptFilterToConcept = `FILTER ( ${concepts.map(concept => `STRENDS (?toId,'${concept}')` ) .join (" || ")} )`
+
+	// this query gets all the edges for the given list of uris
+	// with a limit applied to not return everything
+	const sparql = `
+	PREFIX rdf: <http://www.w3.org/2000/01/rdf-schema#>
+	PREFIX fn: <http://www.w3.org/2005/xpath-functions#>
+
+	SELECT DISTINCT
+	 (fn:head((?fromUri, ?fromId)) as ?from)
+	 (fn:head((?toUri, ?toId)) as ?to)
+	 (fn:string-join((?from, ?lbl, ?to), "-") as ?id)
+	 (fn:tail(fn:tokenize(?lbl, "#")) as ?label)
+	 (fn:head(fn:tokenize(?fromId, "#")) as ?fromType)
+	 (fn:head(fn:tokenize(?toId, "#")) as ?toType)
+	WHERE {
+	 {
+			 ## From concept to entity
+				?fromId  ?lbl ?toId .
+							?toUri rdf:hasId ?toId .
+						 optional { ?fromUri rdf:hasId ?fromId}
+						${conceptFilterFromConcept}
+		} UNION {
+			 ?fromId  ?lbl ?toId .
+							?fromUri rdf:hasId ?fromId .
+				 optional { ?toUri rdf:hasId ?toId}
+						 ${conceptFilterToConcept}
+		 }
+	}
+	`
+
+	// build a cts.query that omits archived documents from smart mastering
+	const archivedCollections = cts.collectionMatch('sm-*-archived').toArray()
+	const query = cts.notQuery(cts.collectionQuery(archivedCollections))
+
+	// run the sparql query while ignoring archived docs
+	const triples = sem.sparql(sparql, null, null, sem.store(null, query))
+	let uris = []
+ for (let t of triples) {
+	 uris.push(t.from)
+	 uris.push(t.to)
+ }
+
+ const edgeCounts = getEdgeCounts(uris)
+
+ /* This code gets the next 2 levels
+ let otherEntities = getEntities(uris, opts)
+ resp.nodes = otherEntities.nodes
+ resp.edges = otherEntities.edges
+ */
+ // now add the edges from the concept
+ for (let t of triples) {
+	 resp.edges[t.id] = {
+		 from: t.from,
+		 to: t.to,
+		 id: t.id,
+		 label: t.label,
+		 fromType: t.fromType,
+		 toType: t.toType
+	 }
+	 let uri = t.from
+	 let doc = cts.doc(uri)
+	 let haveDoc = false
+	 // the actual entity which could be on the to or from side
+	 if (fn.exists(doc)) {
+		 haveDoc = true
+	 } else {
+		 uri = t.to
+		 doc = cts.doc(uri)
+		 if (fn.exists(doc)) {
+			 haveDoc=true
+		 }
+	 }
+	 if( haveDoc) {
+		 let entity = fn.head(doc.xpath('*:envelope/*:instance/node()[local-name-from-QName(node-name(.)) = ../*:info/*:title]'))
+
+		 // use metadata from the model to grab the "label" out of the entity
+		 // the label is specified in envision's UI on the Modeler page
+		 const entityName = doc.xpath('*:envelope/*:instance/*:info/*:title/string()').toString();
+		 const entityId = entityName.toLowerCase()
+		 const modelNode = model.nodes[entityId] || {};
+		 const labelField = modelNode.labelField;
+
+		 // grab the label or default to the uri
+		 const label = (!!labelField) ? entity.xpath(`.//${labelField}/string()`) : uri
+
+		 // convert xml to json map
+		 if (entity instanceof Element) {
+			 entity = entity.xpath('node()').toArray().reduce((item, el) => {
+				 item[el.xpath('local-name(.)')] = el.xpath('string(.)')
+				 return item;
+			 }, {})
+		 }
+
+		 resp.nodes[uri] = {
+			 id: uri,
+			 uri: uri,
+			 entityName: entityName,
+			 label: label,
+			 entity: entity,
+			 edgeCounts: edgeCounts[uri] || {},
+
+			 // grab the DHF provenance data out of the jobs db
+			 prov: provHelper.getProv(uri),
+			 isConcept: false
+		 }
+	 }
+ }
+
+ return resp
+
+}
+
+exports.getEntitiesRelatedToConcept = getEntitiesRelatedToConcept;
 exports.getEntities = getEntities;
 exports.runQuery = runQuery
 exports.getValues = getValues

--- a/middle-tier/src/main/resources/envision-modules/root/envision/search/relatedEntitiesToConcept.api
+++ b/middle-tier/src/main/resources/envision-modules/root/envision/search/relatedEntitiesToConcept.api
@@ -1,0 +1,21 @@
+{
+    "functionName": "relatedEntitiesToConcept",
+    "params": [
+      {
+        "datatype": "string",
+        "name": "concept"
+      },
+			{
+        "datatype": "int",
+        "name": "page"
+      },
+			{
+        "datatype": "int",
+        "name": "pageLength"
+      }
+    ],
+    "return": {
+      "datatype": "jsonDocument",
+      "$javaClass":"com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/middle-tier/src/main/resources/envision-modules/root/envision/search/relatedEntitiesToConcept.sjs
+++ b/middle-tier/src/main/resources/envision-modules/root/envision/search/relatedEntitiesToConcept.sjs
@@ -1,0 +1,9 @@
+const ents = require('/envision/entities.sjs');
+
+var concept;
+var page;
+var pageLength;
+
+const connectionLimit = pageLength
+const results = ents.getEntitiesRelatedToConcept([concept], { connectionLimit })
+results;

--- a/ui/src/api/SearchApi.js
+++ b/ui/src/api/SearchApi.js
@@ -230,5 +230,13 @@ export default {
 			console.error('error:', error);
 			return error;
 		});
+	},
+	getEntitiesRelatedToConcept ({ concept, page, pageLength }) {
+		return axios.post('/api/explore/related-entities-to-concept/', { concept, page, pageLength })
+		.then(response => response.data)
+		.catch(error => {
+			console.error('error:', error);
+			return error;
+		});
 	}
 };

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -386,6 +386,13 @@ const explore = {
 					commit('addDocs', response)
 				})
 		},
+		getEntitiesRelatedToConcept({ commit }, { concept, page, pageLength }) {
+			return searchApi
+				.getEntitiesRelatedToConcept({ concept, page, pageLength })
+				.then(response => {
+					commit('addDocs', response)
+				})
+		},
 		getHistory({ commit }, uri) {
 			return masteringApi.getHistory(uri)
 				.then(response => {

--- a/ui/src/views/ExplorerPage.vue
+++ b/ui/src/views/ExplorerPage.vue
@@ -706,16 +706,28 @@ export default {
 						y: e.event.y
 					}
 
-					let items = _.sortBy(Object.values(node.edgeCounts), 'label').map(e => {
-						return {
-							label: `Expand ${e.label} (${e.count})`,
-							action: 'expand',
-							rel: {
-								uri: this.currentNode.id,
-								label: e.label
+					let items = []
+					if (!node.isConcept) {
+						items = _.sortBy(Object.values(node.edgeCounts), 'label').map(e => {
+							return {
+								label: `Expand ${e.label} (${e.count})`,
+								action: 'expand',
+								rel: {
+									uri: this.currentNode.id,
+									label: e.label
+								}
 							}
-						}
-					})
+						})
+					} else {
+						// TODO - change to be like normal entities and show numbers?
+						items.push({
+							label: 'Expand concept ' + node.label,
+							action: 'expandConcept',
+							rel: {
+								concept: node.label
+							}
+						})
+          }
 
 					if (node.uri && node.uri.match('/com.marklogic.smart-mastering/merged/')) {
 						items.push({
@@ -747,6 +759,9 @@ export default {
 				case 'expand':
 					this.expandRelationship(item.rel)
 					break
+				case 'expandConcept':
+					this.expandConcept(item.rel)
+					break;
 				case 'unmerge':
 					this.confirmUnmergeMenu = true
 					break;
@@ -760,6 +775,12 @@ export default {
 			const page = 1
 			const pageLength = 10
 			this.$store.dispatch('explore/getRelatedEntities', { uri, label, page, pageLength })
+		},
+		expandConcept({ concept }) {
+			// TODO: move this to store
+			const page = 1
+			const pageLength = 10
+			this.$store.dispatch('explore/getEntitiesRelatedToConcept', { concept, page, pageLength })
 		},
 		mergeHistory(uri) {
 			this.$router.push({ name: 'root.explorer.compare', query: { uri } })


### PR DESCRIPTION
Slightly different behaviour when right clicking on concepts - with entities we show related items by type so you can determine what you want to expand. For concepts you expand everything. (Should probably allow both approaches - ie expand all and expand by type)